### PR TITLE
feature: support echo-cancel on PipeWire 0.3.30+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 <!-- next-header -->
 ## [Unreleased] - TBD
 
+### Added
+
+* Support for echo-cancellation on PipeWire 0.3.30+.
 
 ## [0.2.0] - 2021-05-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,9 @@ dependencies = [
  "directories-next",
  "env_logger",
  "gstreamer",
+ "lenient_semver",
  "log",
+ "regex",
  "serde",
  "structopt",
 ]
@@ -350,6 +352,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lenient_semver"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de8de3f4f3754c280ce1c8c42ed8dd26a9c8385c2e5ad4ec5a77e774cea9c1ec"
+dependencies = [
+ "lenient_semver_parser",
+ "semver",
+]
+
+[[package]]
+name = "lenient_semver_parser"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f650c1d024ddc26b4bb79c3076b30030f2cf2b18292af698c81f7337a64d7d6"
+dependencies = [
+ "lenient_semver_version_builder",
+ "semver",
+]
+
+[[package]]
+name = "lenient_semver_version_builder"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9049f8ff49f75b946f95557148e70230499c8a642bf2d6528246afc7d0282d17"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "lexical-core"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +619,12 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "semver"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ env_logger = '0.8'
 gstreamer = "0.16"
 directories-next = '2'
 ctrlc = { version = "3", features = ["termination"] }
+regex = { version = "1", no-default-features = true, features = ["std", "perf"]}
+lenient_semver = "0.4"
 
 [dependencies.config]
 version = '0.11'


### PR DESCRIPTION
Detect PipeWire version and enable echo-cancellation if v >= 0.3.30. It
still uses PipeWire's pulseaudio layer to do everything.
