### PR TITLE
Feature: command droidcam from cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,12 +99,14 @@ dependencies = [
  "ctrlc",
  "directories-next",
  "env_logger",
+ "futures",
  "gstreamer",
  "lenient_semver",
  "log",
  "regex",
  "serde",
  "structopt",
+ "tokio",
 ]
 
 [[package]]
@@ -148,12 +150,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -174,6 +192,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-io"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
+
+[[package]]
 name = "futures-macro"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +209,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
@@ -199,9 +229,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
  "autocfg",
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
@@ -477,6 +511,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -768,6 +812,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
+dependencies = [
+ "autocfg",
+ "num_cpus",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,15 +11,36 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "async-stream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "atty"
@@ -39,10 +60,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bumpalo"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
@@ -95,6 +134,7 @@ name = "dcamctl"
 version = "0.3.0-dev"
 dependencies = [
  "anyhow",
+ "async-stream",
  "config",
  "ctrlc",
  "directories-next",
@@ -104,8 +144,11 @@ dependencies = [
  "lenient_semver",
  "log",
  "regex",
+ "reqwest",
  "serde",
+ "serde-aux",
  "structopt",
+ "termion",
  "tokio",
 ]
 
@@ -137,16 +180,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "env_logger"
-version = "0.8.3"
+name = "encoding_rs"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
  "humantime",
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -347,10 +415,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.3.2"
+name = "h2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -365,10 +458,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+
+[[package]]
+name = "httpdate"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -377,6 +555,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "js-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -429,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "linked-hash-map"
@@ -449,10 +642,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
 name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mio"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "muldiv"
@@ -481,6 +708,15 @@ dependencies = [
  "lexical-core",
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -524,16 +760,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.7.2"
+name = "numtoa"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "paste"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project-lite"
@@ -632,6 +880,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_termios"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+dependencies = [
+ "redox_syscall",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +916,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "reqwest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +969,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-aux"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77eb8c83f6ebaedf5e8f970a8a44506b180b8e6268de03885c8547031ccaee00"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,10 +990,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+
+[[package]]
+name = "socket2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "static_assertions"
@@ -752,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -783,6 +1124,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall",
+ "redox_termios",
 ]
 
 [[package]]
@@ -815,14 +1168,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.6.0"
+name = "tinyvec"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tokio"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c79ba603c337335df6ba6dd6afc38c38a7d5e1b0c871678439ea973cd62a118e"
 dependencies = [
  "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
  "num_cpus",
+ "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -832,6 +1221,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+
+[[package]]
+name = "tracing"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -853,6 +1292,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "version-compare"
 version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,10 +1316,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+dependencies = [
+ "cfg-if",
+ "serde",
+ "serde_json",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -900,6 +1439,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ directories-next = '2'
 ctrlc = { version = "3", features = ["termination"] }
 regex = { version = "1", default-features = false, features = ["std", "perf"]}
 lenient_semver = "0.4"
+futures = "0.3"
 
 [dependencies.config]
 version = '0.11'
@@ -27,6 +28,10 @@ features = ['derive']
 version = '0.3'
 default-features = false
 features = ['suggestions']
+
+[dependencies.tokio]
+version = "1"
+features = ["rt-multi-thread"]
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ ctrlc = { version = "3", features = ["termination"] }
 regex = { version = "1", default-features = false, features = ["std", "perf"]}
 lenient_semver = "0.4"
 futures = "0.3"
+termion = "1"
+async-stream = "0.3"
+serde-aux = { version = "2", default-features = false }
 
 [dependencies.config]
 version = '0.11'
@@ -31,7 +34,12 @@ features = ['suggestions']
 
 [dependencies.tokio]
 version = "1"
-features = ["rt-multi-thread"]
+features = ["rt-multi-thread", "signal"]
+
+[dependencies.reqwest]
+version = "0.11"
+default-features = false
+features = ["json"]
 
 [profile.release]
 lto = true

--- a/src/cam_info.rs
+++ b/src/cam_info.rs
@@ -1,0 +1,18 @@
+use serde_aux::prelude::*;
+
+#[derive(Debug, serde::Deserialize)]
+pub struct CamInfo {
+    pub curvals: CurrentValues,
+    pub avail: Option<Available>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct CurrentValues {
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub zoom: u16,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct Available {
+    pub zoom: Vec<String>,
+}

--- a/src/cam_info.rs
+++ b/src/cam_info.rs
@@ -10,6 +10,10 @@ pub struct CamInfo {
 pub struct CurrentValues {
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub zoom: u16,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub crop_x: u32,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub crop_y: u32,
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/src/cam_info.rs
+++ b/src/cam_info.rs
@@ -14,6 +14,8 @@ pub struct CurrentValues {
     pub crop_x: u32,
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub crop_y: u32,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub quality: u16,
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/src/control.rs
+++ b/src/control.rs
@@ -51,8 +51,9 @@ impl CamControl {
     fn display_status(&mut self) -> Result<()> {
         if let Some((zoom_idx, zoom_end)) = self.zoom_index() {
             let p = (100 * zoom_idx) / zoom_end;
+            let q = self.cam_info.curvals.quality;
             if log_enabled!(log::Level::Error) {
-                write!(self.stdout, "Zoom: {:2} %\r", p)?;
+                write!(self.stdout, "Zoom: {:2} %, Quality: {:2} %\r", p, q)?;
                 self.stdout.flush()?;
             }
         }
@@ -141,6 +142,10 @@ async fn process_commands_inner(control: CamControl) -> Result<()> {
     while let Some(cmd) = cmds.next().await {
         match cmd {
             Command::Quit => {
+                if log_enabled!(log::Level::Error) {
+                    write!(control.stdout, "{}", termion::clear::CurrentLine)?;
+                    control.stdout.flush()?;
+                }
                 control
                     .quit
                     .send(())

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,0 +1,194 @@
+use crate::cam_info::CamInfo;
+use anyhow::*;
+use futures::{FutureExt, Stream, StreamExt};
+use log::*;
+use termion::{event::Key, input::TermRead};
+use tokio::{signal::unix::SignalKind, sync::oneshot::Sender};
+
+enum Command {
+    Quit,
+    ZoomIn,
+    ZoomOut,
+    Nothing,
+}
+
+#[derive(Debug)]
+struct CamControl {
+    quit: Sender<()>,
+    port: u16,
+    cam_info: CamInfo,
+}
+
+impl CamControl {
+    async fn new(quit: Sender<()>, port: u16) -> Result<CamControl> {
+        let cam_info = get_cam_info(port, true).await?;
+
+        Ok(CamControl {
+            quit,
+            port,
+            cam_info,
+        })
+    }
+
+    async fn refresh(&mut self) -> Result<()> {
+        let new = get_cam_info(self.port, false).await?;
+
+        self.cam_info.curvals = new.curvals;
+
+        Ok(())
+    }
+
+    fn zoom_index(&self) -> Option<(usize, usize)> {
+        let h = &self.cam_info.avail.as_ref()?.zoom;
+        let idx = h.iter().position(|e| {
+            if let Ok(i) = e.parse::<u16>() {
+                i == self.cam_info.curvals.zoom
+            } else {
+                false
+            }
+        })?;
+
+        Some((idx, h.len()))
+    }
+
+    fn increment_zoom_index(&self) -> Result<usize> {
+        let (idx, len) = self
+            .zoom_index()
+            .ok_or_else(|| anyhow!("internal error while zooming in"))?;
+
+        if idx < len {
+            Ok(idx + 1)
+        } else {
+            Ok(idx)
+        }
+    }
+
+    fn decrement_zoom_index(&self) -> Result<usize> {
+        let (idx, _) = self
+            .zoom_index()
+            .ok_or_else(|| anyhow!("internal error while zooming out"))?;
+
+        if idx > 0 {
+            Ok(idx - 1)
+        } else {
+            Ok(0)
+        }
+    }
+}
+
+async fn get_cam_info(port: u16, init: bool) -> Result<CamInfo> {
+    let show = if init { "1" } else { "0" };
+    let c = reqwest::get(format!(
+        "http://127.0.0.1:{}/status.json?show_avail={}",
+        port, show
+    ))
+    .await?
+    .json::<CamInfo>()
+    .await?;
+
+    trace!("{:?}", c);
+
+    Ok(c)
+}
+
+pub async fn process_commands(port: u16) -> Result<()> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    let j = tokio::task::spawn(async move {
+        match CamControl::new(tx, port).await {
+            Ok(c) => {
+                match process_commands_inner(c).await {
+                    Ok(_) => {}
+                    Err(e) => error!("{}", e),
+                };
+            }
+            Err(e) => error!("{}", e),
+        };
+    });
+
+    futures::future::select(rx, j).await;
+
+    Ok(())
+}
+
+async fn process_commands_inner(control: CamControl) -> Result<()> {
+    let mut cmds = input_commands().boxed();
+    let mut control = control;
+    while let Some(cmd) = cmds.next().await {
+        match cmd {
+            Command::Quit => {
+                control
+                    .quit
+                    .send(())
+                    .map_err(|_| anyhow!("broken channel"))?;
+                break;
+            }
+            Command::Nothing => {}
+            Command::ZoomIn => {
+                let new_zoom = &control.increment_zoom_index()?;
+                reqwest::get(format!(
+                    "http://127.0.0.1:{}/ptz?zoom={}",
+                    control.port, new_zoom
+                ))
+                .await?;
+            }
+            Command::ZoomOut => {
+                let new_zoom = &control.decrement_zoom_index()?;
+                reqwest::get(format!(
+                    "http://127.0.0.1:{}/ptz?zoom={}",
+                    control.port, new_zoom
+                ))
+                .await?;
+            }
+        }
+
+        control.refresh().await?;
+    }
+
+    Ok(())
+}
+
+pub async fn stop_signals() -> Result<()> {
+    let mut i = tokio::signal::unix::signal(SignalKind::interrupt())?;
+    let mut t = tokio::signal::unix::signal(SignalKind::terminate())?;
+    let mut q = tokio::signal::unix::signal(SignalKind::quit())?;
+
+    let is = i.recv().boxed_local();
+    let ts = t.recv().boxed_local();
+    let qs = q.recv().boxed_local();
+
+    futures::future::select_all(vec![is, ts, qs]).await;
+
+    Ok(())
+}
+
+fn input_commands() -> impl Stream<Item = Command> {
+    let keys = stdin_stream();
+
+    use Command::*;
+    keys.map(|k| match k {
+        Key::Char('q') => Quit,
+        Key::Char('z') => ZoomIn,
+        Key::Char('Z') => ZoomOut,
+        _ => Nothing,
+    })
+}
+
+fn stdin_stream() -> impl Stream<Item = Key> {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Key>(16);
+
+    tokio::task::spawn_blocking(move || {
+        let mut keys = std::io::stdin().keys();
+        while let Some(Ok(k)) = keys.next() {
+            tx.blocking_send(k).unwrap();
+        }
+    });
+
+    let stream = async_stream::stream! {
+        while let Some(item) = rx.recv().await {
+            yield item;
+        }
+    };
+
+    stream
+}

--- a/src/control.rs
+++ b/src/control.rs
@@ -170,7 +170,7 @@ async fn process_commands_inner(control: CamControl) -> Result<()> {
                 .await?;
             }
             Command::PanLeft => {
-                let new_x = &control.cam_info.curvals.crop_x - 1;
+                let new_x = &control.cam_info.curvals.crop_x.max(1) - 1;
                 reqwest::get(format!(
                     "http://127.0.0.1:{}/settings/crop_x?set={}",
                     control.port, new_x
@@ -186,7 +186,7 @@ async fn process_commands_inner(control: CamControl) -> Result<()> {
                 .await?;
             }
             Command::PanUp => {
-                let new_x = &control.cam_info.curvals.crop_y - 1;
+                let new_x = &control.cam_info.curvals.crop_y.max(1) - 1;
                 reqwest::get(format!(
                     "http://127.0.0.1:{}/settings/crop_y?set={}",
                     control.port, new_x

--- a/src/control.rs
+++ b/src/control.rs
@@ -16,6 +16,8 @@ enum Command {
     PanRight,
     PanUp,
     PanDown,
+    QualityUp,
+    QualityDown,
 }
 
 #[derive(Debug)]
@@ -194,6 +196,22 @@ async fn process_commands_inner(control: CamControl) -> Result<()> {
                 ))
                 .await?;
             }
+            Command::QualityUp => {
+                let new_q = &control.cam_info.curvals.quality + 1;
+                reqwest::get(format!(
+                    "http://127.0.0.1:{}/settings/quality?set={}",
+                    control.port, new_q
+                ))
+                .await?;
+            },
+            Command::QualityDown => {
+                let new_q = &control.cam_info.curvals.quality - 1;
+                reqwest::get(format!(
+                    "http://127.0.0.1:{}/settings/quality?set={}",
+                    control.port, new_q
+                ))
+                .await?;
+            },
         }
 
         control.refresh().await?;
@@ -225,6 +243,8 @@ fn input_commands() -> impl Stream<Item = Command> {
         Key::Char('q') => Quit,
         Key::Char('z') => ZoomIn,
         Key::Char('Z') => ZoomOut,
+        Key::Char('t') => QualityUp,
+        Key::Char('T') => QualityDown,
         Key::Left => PanLeft,
         Key::Right => PanRight,
         Key::Up => PanUp,

--- a/src/control.rs
+++ b/src/control.rs
@@ -12,6 +12,10 @@ enum Command {
     ZoomIn,
     ZoomOut,
     Nothing,
+    PanLeft,
+    PanRight,
+    PanUp,
+    PanDown,
 }
 
 #[derive(Debug)]
@@ -19,7 +23,7 @@ struct CamControl {
     quit: Sender<()>,
     port: u16,
     cam_info: CamInfo,
-    stdout: Stdout
+    stdout: Stdout,
 }
 
 impl CamControl {
@@ -30,7 +34,7 @@ impl CamControl {
             quit,
             port,
             cam_info,
-            stdout: std::io::stdout()
+            stdout: std::io::stdout(),
         })
     }
 
@@ -158,6 +162,38 @@ async fn process_commands_inner(control: CamControl) -> Result<()> {
                 ))
                 .await?;
             }
+            Command::PanLeft => {
+                let new_x = &control.cam_info.curvals.crop_x - 1;
+                reqwest::get(format!(
+                    "http://127.0.0.1:{}/settings/crop_x?set={}",
+                    control.port, new_x
+                ))
+                .await?;
+            }
+            Command::PanRight => {
+                let new_x = &control.cam_info.curvals.crop_x + 1;
+                reqwest::get(format!(
+                    "http://127.0.0.1:{}/settings/crop_x?set={}",
+                    control.port, new_x
+                ))
+                .await?;
+            }
+            Command::PanUp => {
+                let new_x = &control.cam_info.curvals.crop_y - 1;
+                reqwest::get(format!(
+                    "http://127.0.0.1:{}/settings/crop_y?set={}",
+                    control.port, new_x
+                ))
+                .await?;
+            }
+            Command::PanDown => {
+                let new_x = &control.cam_info.curvals.crop_y + 1;
+                reqwest::get(format!(
+                    "http://127.0.0.1:{}/settings/crop_y?set={}",
+                    control.port, new_x
+                ))
+                .await?;
+            }
         }
 
         control.refresh().await?;
@@ -189,6 +225,10 @@ fn input_commands() -> impl Stream<Item = Command> {
         Key::Char('q') => Quit,
         Key::Char('z') => ZoomIn,
         Key::Char('Z') => ZoomOut,
+        Key::Left => PanLeft,
+        Key::Right => PanRight,
+        Key::Up => PanUp,
+        Key::Down => PanDown,
         _ => Nothing,
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ impl Dcam {
         );
         show!(Warn, "\r  Video     : {}\r", device_str);
 
-        show!("'q': quit, 'z'/'Z': zoom, 't'/'T': quality, arrows: pan.\r");
+        show!("Press 'q': quit, 'z'/'Z': zoom, 't'/'T': quality, arrows: pan.\r");
 
         Ok(Dcam {
             port,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ impl Dcam {
         );
         show!(Warn, "\r  Video     : {}\r", device_str);
 
-        show!("Press 'q' to disconnect, 'z'/'Z' to zoom in/out, arrows to pan.\r");
+        show!("'q': quit, 'z'/'Z': zoom, 't'/'T': quality, arrows: pan.\r");
 
         Ok(Dcam {
             port,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ impl Dcam {
         );
         show!(Warn, "\r  Video     : {}\r", device_str);
 
-        show!("Press 'q' to disconnect, 'z'/'Z' to zoom in/out.\r");
+        show!("Press 'q' to disconnect, 'z'/'Z' to zoom in/out, arrows to pan.\r");
 
         Ok(Dcam {
             port,


### PR DESCRIPTION
This adds support for sending commands to droidcam from the terminal. Commands are: zoom in/out, quality up/down, and panning.

Control of the device is done via http with reqwest, and terminal support is done with termion.