### PR TITLE
Autodetect video resolution when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ dcamctl 0.2.1
 
 ## Configuration
 
-dcamctl doesn't create a configuration file for you, but looks for it in in `$XDG_CONFIG_HOME/dcamctl/config.yml` or `$HOME/.config/dcamctl/config.yml`. See the default configuration file at [`config.yml`](config.yml) for an example.
+dcamctl doesn't create a configuration file for you, but looks for it in in `$XDG_CONFIG_HOME/dcamctl/config.yml` or `$HOME/.config/dcamctl/config.yml`. See the default configuration file at [`config.yml`][2] for an example.
 
 ### Configuration keys
 
@@ -151,3 +151,4 @@ dual licensed as above, without any additional terms or conditions.
 [ip webcam]: https://play.google.com/store/apps/details?id=com.pas.webcam
 [for example here]: https://joyofandroid.com/how-to-enable-usb-debugging-on-android/
 [1]: https://github.com/umlaeute/v4l2loopback
+[2]: https://github.com/gourlaysama/dcamctl/blob/v0.2.1/config.yml

--- a/config.yml
+++ b/config.yml
@@ -2,5 +2,5 @@
 # (fallback value if the key isn't present in the config file or on the command line)
 port: 8080
 device: "/dev/video0"
-resolution: "640x480"
+resolution: "auto"
 no_audio: false

--- a/src/cam_info.rs
+++ b/src/cam_info.rs
@@ -1,5 +1,7 @@
 use serde_aux::prelude::*;
 
+use crate::config::Resolution;
+
 #[derive(Debug, serde::Deserialize)]
 pub struct CamInfo {
     pub curvals: CurrentValues,
@@ -16,9 +18,26 @@ pub struct CurrentValues {
     pub crop_y: u32,
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub quality: u16,
+    #[serde(with = "resolution")]
+    pub video_size: Resolution,
 }
 
 #[derive(Debug, serde::Deserialize)]
 pub struct Available {
     pub zoom: Vec<String>,
+}
+
+mod resolution {
+    use super::Resolution;
+    use serde::{de, Deserialize, Deserializer};
+    use std::str::FromStr;
+
+    pub fn deserialize<'de, D>(d: D) -> Result<Resolution, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(d)?;
+
+        FromStr::from_str(&s).map_err(de::Error::custom)
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,7 +24,7 @@ pub struct ProgramOptions {
     /// Output resolution to use.
     ///
     /// The video feed will be resized to this value if needed.
-    /// [default: 640x480]
+    /// [default: auto]
     #[structopt(long, short)]
     pub resolution: Option<String>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ pub struct ProgramConfig {
     pub port: u16,
     pub device: PathBuf,
     #[serde(with = "resolution")]
-    pub resolution: Resolution,
+    pub resolution: Option<Resolution>,
     pub no_audio: bool,
 }
 
@@ -51,12 +51,16 @@ mod resolution {
     use serde::{de, Deserialize, Deserializer};
     use std::str::FromStr;
 
-    pub fn deserialize<'de, D>(d: D) -> Result<Resolution, D::Error>
+    pub fn deserialize<'de, D>(d: D) -> Result<Option<Resolution>, D::Error>
     where
         D: Deserializer<'de>,
     {
         let s = String::deserialize(d)?;
 
-        FromStr::from_str(&s).map_err(de::Error::custom)
+        if s == "auto" {
+            Ok(None)
+        } else {
+            FromStr::from_str(&s).map(Some).map_err(de::Error::custom)
+        }
     }
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -100,7 +100,7 @@ impl CamControl {
     }
 }
 
-async fn get_cam_info(port: u16, init: bool) -> Result<CamInfo> {
+pub async fn get_cam_info(port: u16, init: bool) -> Result<CamInfo> {
     let show = if init { "1" } else { "0" };
     let c = reqwest::get(format!(
         "http://127.0.0.1:{}/status.json?show_avail={}",
@@ -128,7 +128,7 @@ pub async fn process_commands(port: u16) -> Result<()> {
             }
             Err((e, tx)) => {
                 debug!("{}", e);
-                warn!("failed to connect to droidcam controls; falling back.");
+                warn!("failed to connect to droidcam controls; disabling device control.");
                 match process_commands_fallback(tx).await {
                     Ok(_) => {}
                     Err(e) => error!("{}", e),

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ async fn run(options: ProgramOptions) -> Result<ReturnCode> {
     } else {
         AudioSupport::new()?
     };
-    let mut pipeline = Dcam::new(audio, &conf.device, conf.resolution, conf.port)?;
+    let mut pipeline = Dcam::setup(audio, &conf.device, conf.resolution, conf.port).await?;
 
     pipeline.run().await?;
 


### PR DESCRIPTION
When resolution is set to `auto` (the default), it queries the device
for its current resolution and uses that.
